### PR TITLE
fix: removes unused fields so queries don't error trying to find them

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -62,7 +62,6 @@ export const pageQuery = graphql`
           frontmatter {
             date(formatString: "MMMM DD, YYYY")
             title
-            description
           }
         }
       }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -89,7 +89,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
-        description
       }
     }
   }


### PR DESCRIPTION
Because there isn't a `description` key in any of the Markdown files' frontmatter a description field isn't being added to the GraphQL schema. Removing these fields from the GraphQL queries removes the errors and lets things build okay. 

I think this should fix things!